### PR TITLE
refactor(device): remove IIDLossDevice

### DIFF
--- a/rattan-cli/src/docker.rs
+++ b/rattan-cli/src/docker.rs
@@ -18,7 +18,7 @@ use rattan::{
 use rattan::{
     devices::{
         delay::{DelayDevice, DelayDeviceConfig},
-        loss::{IIDLossDevice, IIDLossDeviceConfig},
+        loss::{LossDevice, LossDeviceConfig},
         ControlInterface, Device, StdPacket,
     },
     netem_trace::Bandwidth,
@@ -209,11 +209,11 @@ pub fn docker_main(opts: CommandArgs) -> anyhow::Result<()> {
                     right_fd.push(right_delay_rx);
                 }
                 if let Some(loss) = loss {
-                    let left_loss_device = IIDLossDevice::<StdPacket, StdRng>::new(rng.clone());
-                    let right_loss_device = IIDLossDevice::<StdPacket, StdRng>::new(rng);
+                    let left_loss_device = LossDevice::<StdPacket, StdRng>::new(rng.clone());
+                    let right_loss_device = LossDevice::<StdPacket, StdRng>::new(rng);
                     let right_loss_ctl = right_loss_device.control_interface();
                     right_loss_ctl
-                        .set_config(IIDLossDeviceConfig::new(loss))
+                        .set_config(LossDeviceConfig::new([loss]))
                         .unwrap();
                     let (left_loss_rx, left_loss_tx) = machine.add_device(left_loss_device);
                     info!(left_loss_rx, left_loss_tx);

--- a/rattan-cli/src/main.rs
+++ b/rattan-cli/src/main.rs
@@ -5,7 +5,7 @@ use rattan::core::{RattanMachine, RattanMachineConfig};
 use rattan::devices::bandwidth::{queue::InfiniteQueue, BwDevice, BwDeviceConfig, MAX_BANDWIDTH};
 use rattan::devices::delay::{DelayDevice, DelayDeviceConfig};
 use rattan::devices::external::VirtualEthernet;
-use rattan::devices::loss::{IIDLossDevice, IIDLossDeviceConfig};
+use rattan::devices::loss::{LossDevice, LossDeviceConfig};
 use rattan::devices::{ControlInterface, Device, StdPacket};
 use rattan::env::{get_std_env, StdNetEnvConfig};
 use rattan::metal::io::AfPacketDriver;
@@ -133,11 +133,11 @@ fn main() {
                     right_fd.push(right_delay_rx);
                 }
                 if let Some(loss) = loss {
-                    let left_loss_device = IIDLossDevice::<StdPacket, StdRng>::new(rng.clone());
-                    let right_loss_device = IIDLossDevice::<StdPacket, StdRng>::new(rng);
+                    let left_loss_device = LossDevice::<StdPacket, StdRng>::new(rng.clone());
+                    let right_loss_device = LossDevice::<StdPacket, StdRng>::new(rng);
                     let right_loss_ctl = right_loss_device.control_interface();
                     right_loss_ctl
-                        .set_config(IIDLossDeviceConfig::new(loss))
+                        .set_config(LossDeviceConfig::new([loss]))
                         .unwrap();
                     let (left_loss_rx, left_loss_tx) = machine.add_device(left_loss_device);
                     info!(left_loss_rx, left_loss_tx);

--- a/rattan/src/devices/loss.rs
+++ b/rattan/src/devices/loss.rs
@@ -1,13 +1,12 @@
 use crate::devices::{Device, Packet};
 use crate::error::Error;
-use crate::utils::sync::{AtomicF64, AtomicRawCell};
+use crate::utils::sync::AtomicRawCell;
 use async_trait::async_trait;
 use netem_trace::LossPattern;
 use rand::Rng;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 use std::fmt::Debug;
-use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use tokio::sync::mpsc;
 use tracing::{debug, info};
@@ -76,24 +75,25 @@ where
             self.inner_pattern = pattern;
             debug!(?self.inner_pattern, "Set inner pattern:");
         }
-        // out-of-range loss rate is treated as 0
-        if self.inner_pattern.len() <= self.prev_loss {
+        let loss_rate = match self.inner_pattern.get(self.prev_loss) {
+            Some(&loss_rate) => loss_rate,
+            None => *self.inner_pattern.last().unwrap_or(&0.0),
+        };
+        let rand_num = self.rng.gen_range(0.0..1.0);
+        if rand_num < loss_rate {
+            self.prev_loss += 1;
+            None
+        } else {
             self.prev_loss = 0;
             Some(packet.packet)
-        } else {
-            let loss_rate = self.inner_pattern[self.prev_loss];
-            let rand_num = self.rng.gen_range(0.0..1.0);
-            if rand_num < loss_rate {
-                self.prev_loss += 1;
-                None
-            } else {
-                self.prev_loss = 0;
-                Some(packet.packet)
-            }
         }
     }
 }
 
+// Loss pattern will repeat the last value until stop dropping packets.
+// For example, the pattern [0.1, 0.2, 0.3] means [0.1, 0.2, 0.3, 0.3, 0.3, ...].
+// Set the last value of the pattern to 0 to limit the maximum number of consecutive packet losses.
+// If you want to drop packets i.i.d., just set the pattern to a single number, such as [0.1].
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[derive(Debug)]
 pub struct LossDeviceConfig {
@@ -174,114 +174,6 @@ where
                 rng,
             },
             control_interface: Arc::new(LossDeviceControlInterface { pattern }),
-        }
-    }
-}
-
-pub struct IIDLossDeviceEgress<P, R>
-where
-    P: Packet,
-    R: Rng,
-{
-    egress: mpsc::UnboundedReceiver<LossPacket<P>>,
-    /// Between 0.0 and 1.0
-    loss: Arc<AtomicF64>,
-    rng: R,
-}
-
-#[async_trait]
-impl<P, R> Egress<P> for IIDLossDeviceEgress<P, R>
-where
-    P: Packet + Send + Sync,
-    R: Rng + Send + Sync,
-{
-    async fn dequeue(&mut self) -> Option<P> {
-        let packet = self.egress.recv().await.unwrap();
-        let loss_rate = self.loss.load(Ordering::Relaxed);
-        let rand_num = self.rng.gen_range(0.0..1.0);
-        if rand_num < loss_rate {
-            None
-        } else {
-            Some(packet.packet)
-        }
-    }
-}
-
-#[cfg_attr(feature = "serde", derive(Deserialize))]
-#[derive(Debug)]
-pub struct IIDLossDeviceConfig {
-    loss: f64,
-}
-
-impl IIDLossDeviceConfig {
-    pub fn new<T: Into<f64>>(loss: T) -> Self {
-        Self { loss: loss.into() }
-    }
-}
-
-pub struct IIDLossDeviceControlInterface {
-    /// Stored as nanoseconds
-    loss: Arc<AtomicF64>,
-}
-
-impl ControlInterface for IIDLossDeviceControlInterface {
-    type Config = IIDLossDeviceConfig;
-
-    fn set_config(&self, config: Self::Config) -> Result<(), Error> {
-        info!("Set loss rate to: {}", config.loss);
-        self.loss.store(config.loss, Ordering::Relaxed);
-        Ok(())
-    }
-}
-
-pub struct IIDLossDevice<P: Packet, R: Rng> {
-    ingress: Arc<LossDeviceIngress<P>>,
-    egress: IIDLossDeviceEgress<P, R>,
-    control_interface: Arc<IIDLossDeviceControlInterface>,
-}
-
-impl<P, R> Device<P> for IIDLossDevice<P, R>
-where
-    P: Packet + Send + Sync + 'static,
-    R: Rng + Send + Sync + 'static,
-{
-    type IngressType = LossDeviceIngress<P>;
-    type EgressType = IIDLossDeviceEgress<P, R>;
-    type ControlInterfaceType = IIDLossDeviceControlInterface;
-
-    fn sender(&self) -> Arc<Self::IngressType> {
-        self.ingress.clone()
-    }
-
-    fn receiver(&mut self) -> &mut Self::EgressType {
-        &mut self.egress
-    }
-
-    fn into_receiver(self) -> Self::EgressType {
-        self.egress
-    }
-
-    fn control_interface(&self) -> Arc<Self::ControlInterfaceType> {
-        Arc::clone(&self.control_interface)
-    }
-}
-
-impl<P, R> IIDLossDevice<P, R>
-where
-    P: Packet,
-    R: Rng,
-{
-    pub fn new(rng: R) -> IIDLossDevice<P, R> {
-        let (rx, tx) = mpsc::unbounded_channel();
-        let loss = Arc::new(AtomicF64::new(0.0));
-        IIDLossDevice {
-            ingress: Arc::new(LossDeviceIngress { ingress: rx }),
-            egress: IIDLossDeviceEgress {
-                egress: tx,
-                loss: loss.clone(),
-                rng,
-            },
-            control_interface: Arc::new(IIDLossDeviceControlInterface { loss }),
         }
     }
 }

--- a/rattan/tests/integration/loss.rs
+++ b/rattan/tests/integration/loss.rs
@@ -4,7 +4,7 @@ use rand::rngs::StdRng;
 use rand::SeedableRng;
 use rattan::core::{RattanMachine, RattanMachineConfig};
 use rattan::devices::external::VirtualEthernet;
-use rattan::devices::loss::{IIDLossDevice, IIDLossDeviceConfig, LossDevice, LossDeviceConfig};
+use rattan::devices::loss::{LossDevice, LossDeviceConfig};
 use rattan::devices::{ControlInterface, Device, StdPacket};
 use rattan::env::{get_std_env, StdNetEnvConfig};
 use rattan::metal::io::AfPacketDriver;
@@ -162,8 +162,8 @@ fn test_iid_loss() {
         runtime.block_on(
             async move {
                 let rng = StdRng::seed_from_u64(42);
-                let left_loss_device = IIDLossDevice::<StdPacket, StdRng>::new(rng.clone());
-                let right_loss_device = IIDLossDevice::<StdPacket, StdRng>::new(rng);
+                let left_loss_device = LossDevice::<StdPacket, StdRng>::new(rng.clone());
+                let right_loss_device = LossDevice::<StdPacket, StdRng>::new(rng);
                 let left_control_interface = left_loss_device.control_interface();
                 let right_control_interface = right_loss_device.control_interface();
                 if control_tx
@@ -236,7 +236,7 @@ fn test_iid_loss() {
         let _span = span!(Level::INFO, "ping_with_loss").entered();
         info!("try to ping with loss set to 0.5");
         left_control_interface
-            .set_config(IIDLossDeviceConfig::new(0.5))
+            .set_config(LossDeviceConfig::new([0.5]))
             .unwrap();
         let _left_ns_guard = NetNsGuard::new(left_ns.clone()).unwrap();
         let handle = std::process::Command::new("ping")


### PR DESCRIPTION
Use `LossDevice` to implement the function of `IIDLossDevice`. Just set the pattern to a single number to do it, such as [0.1].

Closes: #7