### PR TITLE
fix(cli): resolve clap error of `Arguments`

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -45,7 +45,7 @@ static RIGHT_PID: OnceCell<i32> = OnceCell::new();
 
 #[derive(Debug, Parser, Clone)]
 #[command(rename_all = "kebab-case")]
-#[command(propagate_version = true)]
+#[command(version, propagate_version = true)]
 pub struct Arguments {
     // Verbose debug output
     // #[arg(short, long)]
@@ -128,8 +128,10 @@ pub struct Arguments {
     /// Enable packet logging
     #[arg(long)]
     packet_log: bool,
+    // This "requires" field uses an underscore '_' instead of a dash '-' since "packet_log" is a
+    // field name instead of a group name
     /// Packet log path, default to $CACHE_DIR/rattan/packet.log
-    #[arg(long, value_name = "Log File", requires = "packet-log")]
+    #[arg(long, value_name = "Log File", requires = "packet_log")]
     packet_log_path: Option<String>,
 
     /// Command to run in left ns. Only used when in isolated mode


### PR DESCRIPTION
As  described in #72, `clap` complains about the settings of argument parsing when in debug mode.

The "No version information to propagate" error is raised because the main program is not set to display version so there is no version information to propagate. I added `version` macro for `Arguments` struct so that the version can be propagated correctly.

For the error about missing "packet-log" argument or group required by `packet_log_path`, it turns out that "packet-log", unlike other group name required by other keys, is actually a field name in the struct and should be denoted as "packet_log".

Resolves: #72 