### PR TITLE
Correcting a snake_case issue with per-packet delay config file

### DIFF
--- a/rattan-core/src/config/per_packet.rs
+++ b/rattan-core/src/config/per_packet.rs
@@ -16,6 +16,7 @@ use netem_trace::model::DelayPerPacketTraceConfig;
 use serde::{Deserialize, Serialize};
 
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[derive(Clone, Debug)]
 pub enum DelayPerPacketCellBuildConfig {
     Trace(std::path::PathBuf),


### PR DESCRIPTION
This corrects the snake case issue stated in PR #122 