### PR TITLE
Spy cell

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -251,6 +251,12 @@ type = "DelayPerPacket"
 
 trace = "./assets/delay-per-packet.toml"
 
+# Spy Cell Example
+[cells.spy]
+type = "Spy"
+
+path = "/tmp/spy.pcap"
+
 # Shadow Cell Example
 [cells.shadow]
 type = "Shadow"

--- a/guide/src/guide/flexible-configuration.md
+++ b/guide/src/guide/flexible-configuration.md
@@ -56,6 +56,7 @@ Possible cell types:
 - `Delay`: Fixed delay
 - `DelayPerPacket`: Delay specified per-packet
 - `Loss`: Loss pattern
+- `Spy`: Log all packets
 - `Custom`: Custom cell, only specify the cell ID used in link section, and the cell must be built by the user
 
 For example, the following is a cell configuration for a fixed bandwidth cell:

--- a/rattan-core/Cargo.toml
+++ b/rattan-core/Cargo.toml
@@ -15,9 +15,10 @@ backon = "1.2.0"
 bandwidth = "0.3.0"
 bitfield = "0.19.0"
 bytesize = "2.0.1"
-figment = { workspace = true }
 camellia = { git = "https://github.com/minhuw/camellia.git", optional = true }
+dyn-clone = "1.0"
 etherparse = "0.18.0"
+figment = { workspace = true }
 futures = { workspace = true }
 human-bandwidth = { workspace = true }
 ipnet = { version = "2.8.0", features = ["serde"] }
@@ -28,7 +29,7 @@ netem-trace = { workspace = true }
 nix = { workspace = true }
 once_cell = { workspace = true }
 parking_lot = "0.12.1"
-pcap-file = { version = "2.0.0", optional = true }
+pcap-file = { version = "2.0.0" }
 plain = "0.2.3"
 rand = { workspace = true }
 rand_distr = "0.5"
@@ -52,6 +53,7 @@ ctrlc = { workspace = true }
 insta = { version = "1.39.0", features = ["json"] }
 itertools = "0.14.0"
 netns-rs = "0.1.0"
+pnet = "0.35"
 regex = "1.7.3"
 reqwest = { version = "0.12.9", default-features = false, features = [
   "json",
@@ -73,7 +75,7 @@ harness = false
 [features]
 default = []
 http = ["serde", "dep:axum"]
-packet-dump = ["dep:pcap-file"]
+packet-dump = []
 serde = ["dep:serde", "dep:serde_json", "bandwidth/serde", "bytesize/serde", "rand_distr/serde"]
 camellia = ["dep:camellia"]
 

--- a/rattan-core/src/cells/mod.rs
+++ b/rattan-core/src/cells/mod.rs
@@ -14,6 +14,7 @@ pub mod loss;
 pub mod per_packet;
 pub mod router;
 pub mod shadow;
+pub mod spy;
 pub mod token_bucket;
 
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]

--- a/rattan-core/src/cells/spy.rs
+++ b/rattan-core/src/cells/spy.rs
@@ -1,0 +1,314 @@
+use crate::cells::{Cell, ControlInterface, Egress, Ingress, Packet};
+use crate::error::Error;
+use async_trait::async_trait;
+use pcap_file::pcap::{PcapPacket, PcapWriter};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+use std::fmt::Debug;
+use std::io::Write;
+use std::sync::atomic::AtomicI32;
+use std::sync::Arc;
+use std::time::{Duration, SystemTime};
+use tokio::sync::mpsc;
+use tracing::{debug, info};
+
+#[derive(Clone)]
+pub struct SpyCellIngress<P>
+where
+    P: Packet,
+{
+    ingress: mpsc::UnboundedSender<(Duration, P)>,
+}
+
+pub struct SpyCell<P: Packet, W: Write> {
+    ingress: Arc<SpyCellIngress<P>>,
+    egress: SpyCellEgress<P, W>,
+    control_interface: Arc<SpyCellControlInterface<W>>,
+}
+
+pub struct SpyCellEgress<P, W>
+where
+    P: Packet,
+    W: Write,
+{
+    egress: mpsc::UnboundedReceiver<(Duration, P)>,
+    config_rx: mpsc::UnboundedReceiver<SpyCellConfig<W>>,
+    last: tokio::time::Instant,
+    state: AtomicI32,
+    spy: Option<PcapWriter<W>>,
+}
+
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Debug, Clone)]
+pub struct SpyCellConfig<W> {
+    #[cfg_attr(feature = "serde", serde(skip, default = "Option::default"))]
+    pub spy: Option<W>,
+}
+
+pub struct SpyCellControlInterface<W> {
+    config_tx: mpsc::UnboundedSender<SpyCellConfig<W>>,
+}
+
+impl<P, W> SpyCellEgress<P, W>
+where
+    P: Packet + Send + Sync,
+    W: Write,
+{
+    fn set_config(&mut self, config: SpyCellConfig<W>) {
+        debug!("Set inner spy");
+        self.spy = config.spy.map(|spy| {
+            PcapWriter::new(spy)
+                .unwrap_or_else(|err| panic!("Failed to create the spy pcap writer: {err}"))
+        });
+    }
+}
+
+impl<W> SpyCellConfig<W> {
+    pub fn new(spy: impl Into<W>) -> Self {
+        Self {
+            spy: Some(spy.into()),
+        }
+    }
+}
+
+impl<P, W> SpyCell<P, W>
+where
+    P: Packet,
+    W: Write,
+{
+    pub fn new(spy: impl Into<W>) -> Result<SpyCell<P, W>, Error> {
+        let (rx, tx) = mpsc::unbounded_channel();
+        let (config_tx, config_rx) = mpsc::unbounded_channel();
+        Ok(SpyCell {
+            ingress: Arc::new(SpyCellIngress { ingress: rx }),
+            egress: SpyCellEgress {
+                egress: tx,
+                config_rx,
+                last: tokio::time::Instant::now(),
+                state: AtomicI32::new(0),
+                spy: Some(PcapWriter::new(spy.into())?),
+            },
+            control_interface: Arc::new(SpyCellControlInterface { config_tx }),
+        })
+    }
+}
+
+impl<P> Ingress<P> for SpyCellIngress<P>
+where
+    P: Packet + Send,
+{
+    fn enqueue(&self, mut packet: P) -> Result<(), Error> {
+        packet.set_timestamp(tokio::time::Instant::now());
+        self.ingress
+            .send((
+                SystemTime::now()
+                    .duration_since(SystemTime::UNIX_EPOCH)
+                    .expect("Time went backwards"),
+                packet,
+            ))
+            .map_err(|_| Error::ChannelError("Data channel is closed.".to_string()))?;
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl<P, W> Egress<P> for SpyCellEgress<P, W>
+where
+    P: Packet + Send + Sync,
+    W: Write + Send,
+{
+    async fn dequeue(&mut self) -> Option<P> {
+        loop {
+            tokio::select! {
+            biased;
+                Some(config) = self.config_rx.recv() => {
+                    self.set_config(config);
+                }
+                Some((timestamp, packet)) = self.egress.recv() => {
+                    match self.state.load(std::sync::atomic::Ordering::Acquire) {
+                        0 => {
+                            return None;
+                        }
+                        1 => {
+                            return Some(packet);
+                        }
+                        _ => ()
+                    }
+                    assert!(self.last < packet.get_timestamp());
+                    self.last = packet.get_timestamp();
+                    self.spy.as_mut().map(|spy| spy.write_packet(&PcapPacket {
+                            timestamp,
+                            orig_len: packet.length() as u32,
+                            data: packet.as_slice().into(),
+                        }).expect("Failed to register a packet"));
+
+                    return Some(packet)
+                }
+            }
+        }
+    }
+
+    fn change_state(&self, state: i32) {
+        self.state
+            .store(state, std::sync::atomic::Ordering::Release);
+    }
+}
+
+impl<W: Send + 'static> ControlInterface for SpyCellControlInterface<W> {
+    type Config = SpyCellConfig<W>;
+
+    fn set_config(&self, config: Self::Config) -> Result<(), Error> {
+        info!("Changing the spy");
+        self.config_tx
+            .send(config)
+            .map_err(|_| Error::ConfigError("Control channel is closed.".to_string()))?;
+        Ok(())
+    }
+}
+
+impl<P, W> Cell<P> for SpyCell<P, W>
+where
+    P: Packet + Send + Sync + 'static,
+    W: Write + Send + 'static,
+{
+    type IngressType = SpyCellIngress<P>;
+    type EgressType = SpyCellEgress<P, W>;
+    type ControlInterfaceType = SpyCellControlInterface<W>;
+
+    fn sender(&self) -> Arc<Self::IngressType> {
+        self.ingress.clone()
+    }
+
+    fn receiver(&mut self) -> &mut Self::EgressType {
+        &mut self.egress
+    }
+
+    fn into_receiver(self) -> Self::EgressType {
+        self.egress
+    }
+
+    fn control_interface(&self) -> Arc<Self::ControlInterfaceType> {
+        Arc::clone(&self.control_interface)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::fs::File;
+
+    use pnet::{
+        packet::{
+            ethernet::{EtherType, MutableEthernetPacket},
+            ip::IpNextHeaderProtocols,
+            ipv4::MutableIpv4Packet,
+            tcp::MutableTcpPacket,
+        },
+        util::MacAddr,
+    };
+    use tempfile::NamedTempFile;
+
+    use crate::cells::StdPacket;
+
+    use super::*;
+
+    const ETH_HEADER_LEN: usize = 14;
+    const IP_HEADER_LEN: usize = 20;
+    const TCP_HEADER_LEN: usize = 20;
+    const MAX_PAYLOAD_LEN: u64 =
+        (u16::MAX as usize - (ETH_HEADER_LEN + IP_HEADER_LEN + TCP_HEADER_LEN)) as u64;
+
+    fn spy_cell<P: Packet + Sync>() -> (NamedTempFile, SpyCell<P, File>) {
+        let fifo = tempfile::NamedTempFile::with_suffix("spy_raw.pcap").unwrap();
+        let file = File::create(fifo.path()).unwrap();
+        let mut cell = SpyCell::new(file).unwrap();
+        cell.receiver().change_state(2);
+        (fifo, cell)
+    }
+
+    #[tokio::test]
+    async fn test_spy_cell_ordering() {
+        let (spy, mut cell) = spy_cell::<StdPacket>();
+
+        let packet_creation = |id| -> Vec<u8> {
+            let size = if id < MAX_PAYLOAD_LEN as u32 {
+                id as u16
+            } else {
+                MAX_PAYLOAD_LEN as u16
+            };
+            let seq = if id == 0 {
+                0
+            } else if id < MAX_PAYLOAD_LEN as u32 {
+                (id * (id - 1)) / 2 + 1
+            } else {
+                (MAX_PAYLOAD_LEN * (MAX_PAYLOAD_LEN + 1) / 2
+                    + (id as u64 - MAX_PAYLOAD_LEN) * MAX_PAYLOAD_LEN) as u32
+            };
+
+            let mut buffer =
+                vec![0; ETH_HEADER_LEN + IP_HEADER_LEN + TCP_HEADER_LEN + size as usize];
+
+            // ETH header
+            let mut eth_packet = MutableEthernetPacket::new(&mut buffer).unwrap();
+            eth_packet.set_source(MacAddr::from([0x66; 6]));
+            eth_packet.set_destination(MacAddr::from([0x22; 6]));
+            eth_packet.set_ethertype(EtherType::new(0x0800));
+
+            // IP header
+            let mut ip_packet = MutableIpv4Packet::new(&mut buffer[ETH_HEADER_LEN..]).unwrap();
+            ip_packet.set_version(4);
+            ip_packet.set_header_length((IP_HEADER_LEN / 4) as u8);
+            ip_packet.set_total_length(size + TCP_HEADER_LEN as u16 + IP_HEADER_LEN as u16);
+            ip_packet.set_next_level_protocol(IpNextHeaderProtocols::Tcp);
+            ip_packet.set_source([1, 1, 1, 1].into());
+            ip_packet.set_ttl(64);
+            ip_packet.set_destination([2, 2, 2, 2].into());
+
+            // TCP header
+            let mut tcp_packet =
+                MutableTcpPacket::new(&mut buffer[ETH_HEADER_LEN + IP_HEADER_LEN..]).unwrap();
+            tcp_packet.set_source(1);
+            tcp_packet.set_destination(2);
+            tcp_packet.set_sequence(seq);
+            tcp_packet.set_acknowledgement(id);
+            tcp_packet.set_flags(if id == 0 { 0b0000_0010 } else { 0b0001_0000 });
+            tcp_packet.set_data_offset((TCP_HEADER_LEN / 4) as u8);
+            tcp_packet.set_window(u16::MAX);
+
+            // panic!("{buffer:?}");
+
+            buffer
+        };
+
+        let packets = (0..100_000).map(packet_creation);
+
+        let packets_clone = packets.clone();
+        let sender = Arc::clone(&cell.sender());
+        let server = tokio::task::spawn(async move {
+            for packet in packets_clone {
+                sender.enqueue(StdPacket::from_raw_buffer(&packet)).unwrap();
+            }
+        });
+
+        tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+
+        let packets_clone = packets.clone();
+        let client = tokio::spawn(async move {
+            for packet in packets_clone {
+                let new = cell.receiver().dequeue().await.unwrap();
+                assert_eq!(new.as_slice(), packet);
+            }
+        });
+
+        server.await.unwrap();
+        client.await.unwrap();
+
+        let mut last = core::time::Duration::ZERO;
+        let mut spy = pcap_file::pcap::PcapReader::new(spy).unwrap();
+        for packet in packets {
+            let new = spy.next_packet().unwrap().unwrap();
+            assert_eq!(new.data, packet);
+            assert!(new.timestamp >= last, "{:?} < {last:?}", new.timestamp);
+            last = new.timestamp;
+        }
+    }
+}

--- a/rattan-core/src/config/mod.rs
+++ b/rattan-core/src/config/mod.rs
@@ -14,6 +14,7 @@ mod loss;
 mod per_packet;
 mod router;
 mod shadow;
+mod spy;
 mod token_bucket;
 
 pub use bandwidth::*;
@@ -22,6 +23,7 @@ pub use loss::*;
 pub use per_packet::*;
 pub use router::*;
 pub use shadow::*;
+pub use spy::*;
 pub use token_bucket::*;
 
 /// Configuration for the whole Rattan system.
@@ -109,6 +111,7 @@ pub enum CellBuildConfig<P: Packet> {
     Loss(LossCellBuildConfig),
     LossReplay(LossReplayCellBuildConfig),
     Shadow(ShadowCellBuildConfig),
+    Spy(SpyCellBuildConfig),
     DelayPerPacket(DelayPerPacketCellBuildConfig),
     Router(RouterCellBuildConfig),
     TokenBucket(TokenBucketCellBuildConfig),

--- a/rattan-core/src/config/spy.rs
+++ b/rattan-core/src/config/spy.rs
@@ -1,0 +1,65 @@
+use std::ops::Deref as _;
+
+use dyn_clone::DynClone;
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    cells::{spy, Packet},
+    core::CellFactory,
+};
+
+pub trait Write: std::io::Write + dyn_clone::DynClone {}
+
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
+pub enum SpyCellBuildConfig {
+    Path(std::path::PathBuf),
+    #[cfg_attr(feature = "serde", serde(skip))]
+    Config(Box<dyn Write + Send>),
+}
+
+impl SpyCellBuildConfig {
+    pub fn into_factory<P: Packet>(
+        self,
+    ) -> impl CellFactory<spy::SpyCell<P, Box<dyn std::io::Write + Send>>> {
+        move |handle| {
+            let _guard = handle.enter();
+            match self {
+                Self::Path(path) => {
+                    let file = std::fs::File::create(path)?;
+                    let config: Box<dyn std::io::Write + Send> = Box::new(file);
+                    // let config = spy::SpyCellConfig::<Box<dyn std::io::Write>>::new(config);
+                    spy::SpyCell::new(config)
+                }
+                Self::Config(config) => spy::SpyCell::new(config),
+            }
+        }
+    }
+}
+
+impl Clone for SpyCellBuildConfig {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Path(path) => Self::Path(path.clone()),
+            Self::Config(config) => Self::Config(dyn_clone::clone_box(config.deref())),
+        }
+    }
+}
+
+impl std::fmt::Debug for SpyCellBuildConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Path(path) => write!(f, "Path({:?})", path),
+            Self::Config(_config) => write!(f, "Config"),
+        }
+    }
+}
+
+impl From<Box<dyn Write + Send>> for Box<dyn std::io::Write + Send> {
+    fn from(value: Box<dyn Write + Send>) -> Self {
+        value
+    }
+}
+
+impl<W: std::io::Write + DynClone> Write for W {}

--- a/rattan-core/src/error.rs
+++ b/rattan-core/src/error.rs
@@ -36,6 +36,8 @@ pub enum Error {
     #[cfg(feature = "http")]
     #[error("Http server error: {0}")]
     HttpServerError(#[from] HttpServerError),
+    #[error("Pcap error: {0}")]
+    PcapError(#[from] pcap_file::PcapError),
     #[error("Error: {0}")]
     Custom(String),
 }
@@ -176,6 +178,7 @@ impl axum::response::IntoResponse for Error {
             Error::SerdeError(_) => StatusCode::BAD_REQUEST,
             #[cfg(feature = "http")]
             Error::HttpServerError(_) => StatusCode::INTERNAL_SERVER_ERROR,
+            Error::PcapError(_) => StatusCode::INTERNAL_SERVER_ERROR,
             Error::Custom(_) => StatusCode::INTERNAL_SERVER_ERROR,
         };
 
@@ -202,6 +205,7 @@ impl Termination for Error {
             Error::SerdeError(_) => ExitCode::from(65),
             #[cfg(feature = "http")]
             Error::HttpServerError(_) => ExitCode::from(70),
+            Error::PcapError(_) => ExitCode::from(74),
             Error::Custom(_) => ExitCode::from(1),
         }
     }

--- a/rattan-core/src/radix/mod.rs
+++ b/rattan-core/src/radix/mod.rs
@@ -386,6 +386,9 @@ where
                 CellBuildConfig::Shadow(config) => {
                     self.build_cell(id, config.into_factory())?;
                 }
+                CellBuildConfig::Spy(config) => {
+                    self.build_cell(id, config.into_factory())?;
+                }
                 CellBuildConfig::DelayPerPacket(config) => {
                     self.build_cell(id, config.into_factory())?;
                 }

--- a/rattan-core/tests/integration/mod.rs
+++ b/rattan-core/tests/integration/mod.rs
@@ -6,4 +6,5 @@ mod http;
 mod loss;
 mod multipath;
 mod per_packet;
+mod spy;
 mod token_bucket;

--- a/rattan-core/tests/integration/spy.rs
+++ b/rattan-core/tests/integration/spy.rs
@@ -1,0 +1,81 @@
+/// This test need to be run as root (CAP_NET_ADMIN, CAP_SYS_ADMIN and CAP_SYS_RAW)
+/// RUST_LOG=info CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUNNER='sudo -E' cargo test spy --all-features -- --nocapture
+use rattan_core::cells::StdPacket;
+use rattan_core::config::{CellBuildConfig, RattanConfig, SpyCellBuildConfig};
+use rattan_core::env::{StdNetEnvConfig, StdNetEnvMode};
+use rattan_core::metal::io::af_packet::AfPacketDriver;
+use rattan_core::radix::RattanRadix;
+use regex::Regex;
+use std::collections::HashMap;
+use std::io::Cursor;
+use tempfile::NamedTempFile;
+use tracing::{info, instrument, span, Level};
+
+#[instrument]
+#[test_log::test]
+fn test_spy() {
+    let mut config = RattanConfig::<StdPacket> {
+        env: StdNetEnvConfig {
+            mode: StdNetEnvMode::Isolated,
+            client_cores: vec![1],
+            server_cores: vec![3],
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    let file = NamedTempFile::new().unwrap();
+    config.cells.insert(
+        "up_spy".to_string(),
+        CellBuildConfig::Spy(SpyCellBuildConfig::Path(file.path().to_path_buf())),
+    );
+    config.cells.insert(
+        "down_spy".to_string(),
+        CellBuildConfig::Spy(SpyCellBuildConfig::Config(Box::new(
+            Cursor::new(Vec::new()),
+        ))),
+    );
+    config.links = HashMap::from([
+        ("left".to_string(), "up_spy".to_string()),
+        ("up_spy".to_string(), "right".to_string()),
+        ("right".to_string(), "down_spy".to_string()),
+        ("down_spy".to_string(), "left".to_string()),
+    ]);
+    let mut radix = RattanRadix::<AfPacketDriver>::new(config).unwrap();
+    radix.spawn_rattan().unwrap();
+    radix.start_rattan().unwrap();
+
+    // Wait for AfPacketDriver to be ready
+    std::thread::sleep(std::time::Duration::from_millis(100));
+
+    // Through the SpyCell, the average latency should be less than 0.1ms
+    {
+        let _span = span!(Level::INFO, "ping_no_spy").entered();
+        info!("try to ping with no spy");
+        let right_ip = radix.right_ip(1).to_string();
+        let left_handle = radix
+            .left_spawn(None, move || {
+                let handle = std::process::Command::new("ping")
+                    .args([&right_ip, "-c", "10", "-i", "0.3"])
+                    .stdout(std::process::Stdio::piped())
+                    .spawn()
+                    .unwrap();
+                Ok(handle.wait_with_output())
+            })
+            .unwrap();
+        let output = left_handle.join().unwrap().unwrap().unwrap();
+        let stdout = String::from_utf8(output.stdout).unwrap();
+
+        let re = Regex::new(r"time=(\d+)").unwrap();
+        let mut latency = re
+            .captures_iter(&stdout)
+            .flat_map(|cap| cap[1].parse::<f64>())
+            .collect::<Vec<_>>();
+        info!(?latency);
+
+        assert_eq!(latency.len(), 10);
+        latency.drain(0..5);
+        let average_latency = latency.iter().sum::<f64>() / latency.len() as f64;
+        info!("average latency: {}", average_latency);
+        assert!(average_latency <= 0.1);
+    }
+}


### PR DESCRIPTION
Adds a new cell `SpyCell`.

Unlike the `packet_dump` feature, this cell allows the logging of the packet at a specific point in the network.

This is designed to have any type of writer (`std::io::Write`).

The `SpyCellBuildConfig` can take either:
  - a path: this creates the file, useful because the other needs `Clone` and `File` does not implement `Clone`
  - a `Box<dyn Write + Clone>`: can be used with Cursors, to write in memory