### PR TITLE
Not creating the spycell file when it exists

### DIFF
--- a/rattan-core/src/config/spy.rs
+++ b/rattan-core/src/config/spy.rs
@@ -1,4 +1,7 @@
-use std::ops::Deref as _;
+use std::{
+    fs::{File, OpenOptions},
+    ops::Deref as _,
+};
 
 use dyn_clone::DynClone;
 #[cfg(feature = "serde")]
@@ -27,7 +30,11 @@ impl SpyCellBuildConfig {
             let _guard = handle.enter();
             match self {
                 Self::Path(path) => {
-                    let file = std::fs::File::create(path)?;
+                    let file = if path.exists() {
+                        OpenOptions::new().write(true).truncate(true).open(&path)?
+                    } else {
+                        File::create_new(&path)?
+                    };
                     let config: Box<dyn std::io::Write + Send> = Box::new(file);
                     // let config = spy::SpyCellConfig::<Box<dyn std::io::Write>>::new(config);
                     spy::SpyCell::new(config)


### PR DESCRIPTION
This modification enables the opening and truncation of the spycell log file, even when the file is not owned by rattan user (currently root).

It is useful for the case like #39, when the log file is created by a user but rattan needs to edit it (it cannot create it as it exists but is not owned by the right user)

Maybe a log could be interesting to notify that the file already existed.