### PR TITLE
fix: remove redundant memset on af_packet recv

### DIFF
--- a/rattan-core/src/metal/io/af_packet.rs
+++ b/rattan-core/src/metal/io/af_packet.rs
@@ -91,7 +91,11 @@ impl InterfaceReceiver<StdPacket> for AfPacketReceiver {
         let mut sockaddr = mem::MaybeUninit::<libc::sockaddr_ll>::uninit();
         let mut len = mem::size_of_val(&sockaddr) as socklen_t;
 
-        let buf = [0u8; 65537];
+        let buf: mem::MaybeUninit<[u8; 65537]> = mem::MaybeUninit::uninit();
+
+        // Safety: return value (`ret`) of libc::recvfrom is used to mark the initialized part of buffer, which is
+        // exposed out of this function.
+        let buf = unsafe { buf.assume_init() };
 
         let (ret, addr_ll) = unsafe {
             let ret = Errno::result(libc::recvfrom(


### PR DESCRIPTION
#138 Again

It should be noticed that,  when built with cargo 1.86 and `--release` flag, this fix does provide performance gain (450Mbps -> 700Mbps) on a rattan link with no cells. Here are the flamegraphs:

Current main, 1.86
![current main, 1.86](https://github.com/user-attachments/assets/18a6199b-d385-433f-8095-111c6942f6ba)
This fix, 1.86
![this fix, 1.86](https://github.com/user-attachments/assets/6b086f57-1594-4409-8eeb-b866e067be04)

Yet when compiled with cargo 1.89, which is the latest stable version of cargo, there is no difference in neither performance (~800Mbps, yet on another machine) nor flame graph:
Current main, 1.89
![current main, 1.89](https://github.com/user-attachments/assets/cd15cb1b-e64b-41c0-9afe-a7f33bce6d91)
This fix, 1.89
![this fix: 1.86](https://github.com/user-attachments/assets/c19a510c-186e-4b4d-9da0-0596b8879f89)

It seems that cargo 1.89 can optimize out the redundant `memset` that this fix manually handles. 