### PR TITLE
Reduce CI Execution Time

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,10 +40,19 @@ jobs:
           submodules: recursive
       - uses: dtolnay/rust-toolchain@stable
       - run: sudo apt-get update && sudo apt-get install -y iproute2 ethtool iputils-ping iperf3 datamash bc pkg-config m4 libelf-dev libpcap-dev gcc-multilib libnftnl-dev libmnl-dev -y
-      - name: Install LLVM
+      - name: Cache LLVM and Clang
+        id: cache-llvm
+        uses: maxnowack/local-cache@v2
+        with:
+          path: |
+            C:/Program Files/LLVM
+            ./llvm
+          key: llvm-${{ matrix.llvm }}
+      - name: Install LLVM and Clang
         uses: KyleMayes/install-llvm-action@v2
         with:
           version: ${{ matrix.llvm }}
+          cached: ${{ steps.cache-llvm.outputs.cache-hit }}
       - name: Install nextest
         uses: taiki-e/install-action@nextest
       - run: cargo nextest run --profile ci -F http,camellia --release --workspace

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -34,10 +34,19 @@ jobs:
           submodules: recursive
       - uses: dtolnay/rust-toolchain@stable
       - run: sudo apt-get update && sudo apt-get install -y iproute2 ethtool iputils-ping iperf3 datamash bc pkg-config m4 libelf-dev libpcap-dev gcc-multilib libnftnl-dev libmnl-dev -y
-      - name: Install LLVM
+      - name: Cache LLVM and Clang
+        id: cache-llvm
+        uses: maxnowack/local-cache@v2
+        with:
+          path: |
+            C:/Program Files/LLVM
+            ./llvm
+          key: llvm-${{ matrix.llvm }}
+      - name: Install LLVM and Clang
         uses: KyleMayes/install-llvm-action@v2
         with:
           version: ${{ matrix.llvm }}
+          cached: ${{ steps.cache-llvm.outputs.cache-hit }}
       - run: sudo ./scripts/clean_stdenv.sh -a
       - name: Performance verification
         run: |


### PR DESCRIPTION
This PR makes the following CI changes:

1. Removes the concurrency limit for the matrix test. The four tests now run concurrently. Note that this may occasionally cause tests to be retried within an acceptable range (e.g. test_token_bucket_cell_config_update_up passed on TRY 2 in https://github.com/stack-rs/rattan/actions/runs/20236296410/job/58091752061).

2. Adds caching of the LLVM install on our self-hosted runners using [maxnowack/local-cache@v2](https://github.com/maxnowack/local-cache). This reduces LLVM install time from 3–10 minutes (depending on network conditions) to 1~4 minutes (independent of network conditions). The cache cost about 1.5 GB of local storage. We don't use the official [actions/cache](https://github.com/actions/cache) because that cache is stored on GitHub and self-hosted runners remain subject to network limits.