### PR TITLE
refactor(cell): change PacketQueue::dequeue to dequeue_at(ts)

### DIFF
--- a/rattan-core/src/cells/bandwidth/queue/codel.rs
+++ b/rattan-core/src/cells/bandwidth/queue/codel.rs
@@ -179,11 +179,11 @@ where
         }
     }
 
-    fn dequeue(&mut self) -> Option<P> {
+    fn dequeue(&mut self, timestamp: Option<Instant>) -> Option<P> {
         match self.queue.pop_front() {
             Some(mut packet) => {
                 self.now_bytes -= packet.l3_length() + self.config.bw_type.extra_length();
-                let now = Instant::now();
+                let now = timestamp.unwrap_or(Instant::now());
                 let drop = self.should_drop(&packet);
                 trace!(
                     drop,

--- a/rattan-core/src/cells/bandwidth/queue/codel.rs
+++ b/rattan-core/src/cells/bandwidth/queue/codel.rs
@@ -114,8 +114,8 @@ impl<P> CoDelQueue<P>
 where
     P: Packet,
 {
-    fn should_drop(&mut self, packet: &P) -> bool {
-        self.ldelay = Instant::now() - packet.get_timestamp();
+    fn should_drop(&mut self, packet: &P, now: Instant) -> bool {
+        self.ldelay = now - packet.get_timestamp();
         if self.ldelay < self.config.target || self.now_bytes <= self.config.mtu as usize {
             self.first_above_time = None;
             false
@@ -123,12 +123,12 @@ where
             let mut ok_to_drop = false;
             match self.first_above_time {
                 Some(first_above_time) => {
-                    if Instant::now() >= first_above_time {
+                    if now >= first_above_time {
                         ok_to_drop = true;
                     }
                 }
                 None => {
-                    self.first_above_time = Some(Instant::now() + self.config.interval);
+                    self.first_above_time = Some(now + self.config.interval);
                 }
             }
             ok_to_drop
@@ -183,15 +183,15 @@ where
         match self.queue.pop_front() {
             Some(mut packet) => {
                 self.now_bytes -= packet.l3_length() + self.config.bw_type.extra_length();
-                let drop = self.should_drop(&packet);
+                let drop = self.should_drop(&packet, timestamp);
                 trace!(
                     drop,
                     ldelay = ?self.ldelay,
                     count = self.count,
                     lastcount = self.lastcount,
                     dropping = self.dropping,
-                    first_above_time_from_now = ?self.first_above_time.map(|t| t - Instant::now()),
-                    drop_next_from_now = ?self.drop_next - Instant::now(),
+                    first_above_time_from_now = ?self.first_above_time.map(|t| t - timestamp),
+                    drop_next_from_now = ?self.drop_next - timestamp,
                     after_queue_len = self.queue.len(),
                     after_now_bytes = self.now_bytes,
                     "dequeueing a new packet"
@@ -225,9 +225,9 @@ where
                             self.now_bytes -=
                                 packet.l3_length() + self.config.bw_type.extra_length();
 
-                            if self.should_drop(&packet) {
+                            if self.should_drop(&packet, timestamp) {
                                 self.drop_next = self.control_law(self.drop_next);
-                                trace!(drop_next_from_now = ?self.drop_next - Instant::now());
+                                trace!(drop_next_from_now = ?self.drop_next - timestamp);
                             } else {
                                 self.dropping = false;
                                 trace!("Exit dropping state since packet should not drop");
@@ -267,7 +267,7 @@ where
                     trace!(
                         count = self.count,
                         delta,
-                        drop_next_from_now = ?self.drop_next - Instant::now(),
+                        drop_next_from_now = ?self.drop_next - timestamp,
                         "Enter dropping state"
                     );
                 }

--- a/rattan-core/src/cells/bandwidth/queue/codel.rs
+++ b/rattan-core/src/cells/bandwidth/queue/codel.rs
@@ -179,11 +179,10 @@ where
         }
     }
 
-    fn dequeue(&mut self, timestamp: Option<Instant>) -> Option<P> {
+    fn dequeue_at(&mut self, timestamp: Instant) -> Option<P> {
         match self.queue.pop_front() {
             Some(mut packet) => {
                 self.now_bytes -= packet.l3_length() + self.config.bw_type.extra_length();
-                let now = timestamp.unwrap_or(Instant::now());
                 let drop = self.should_drop(&packet);
                 trace!(
                     drop,
@@ -202,7 +201,7 @@ where
                         self.dropping = false;
                         trace!("Exit dropping state since packet should not be dropped");
                     } else {
-                        while self.dropping && now >= self.drop_next {
+                        while self.dropping && timestamp >= self.drop_next {
                             self.count += 1;
                             trace!(
                                 ldelay = ?self.ldelay,
@@ -258,13 +257,13 @@ where
 
                     self.dropping = true;
                     let delta = self.count - self.lastcount;
-                    if delta > 1 && now - self.drop_next < 16 * self.config.interval {
+                    if delta > 1 && timestamp - self.drop_next < 16 * self.config.interval {
                         self.count = delta;
                     } else {
                         self.count = 1;
                     }
                     self.lastcount = self.count;
-                    self.drop_next = self.control_law(now);
+                    self.drop_next = self.control_law(timestamp);
                     trace!(
                         count = self.count,
                         delta,

--- a/rattan-core/src/cells/bandwidth/queue/drophead.rs
+++ b/rattan-core/src/cells/bandwidth/queue/drophead.rs
@@ -1,4 +1,5 @@
 use std::collections::VecDeque;
+use tokio::time::Instant;
 
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
@@ -96,7 +97,7 @@ where
             .is_some_and(|limit| self.queue.len() > limit)
             || self.byte_limit.is_some_and(|limit| self.now_bytes > limit)
         {
-            let _packet = self.dequeue().unwrap();
+            let _packet = self.dequeue(None).unwrap();
             #[cfg(test)]
             tracing::trace!(
                 after_queue_len = self.queue.len(),
@@ -107,7 +108,7 @@ where
         }
     }
 
-    fn dequeue(&mut self) -> Option<P> {
+    fn dequeue(&mut self, _timestamp: Option<Instant>) -> Option<P> {
         match self.queue.pop_front() {
             Some(packet) => {
                 self.now_bytes -= packet.l3_length() + self.bw_type.extra_length();

--- a/rattan-core/src/cells/bandwidth/queue/drophead.rs
+++ b/rattan-core/src/cells/bandwidth/queue/drophead.rs
@@ -90,6 +90,7 @@ where
     }
 
     fn enqueue(&mut self, packet: P) {
+        let timestamp = packet.get_timestamp();
         self.now_bytes += packet.l3_length() + self.bw_type.extra_length();
         self.queue.push_back(packet);
         while self
@@ -97,7 +98,7 @@ where
             .is_some_and(|limit| self.queue.len() > limit)
             || self.byte_limit.is_some_and(|limit| self.now_bytes > limit)
         {
-            let _packet = self.dequeue(None).unwrap();
+            let _packet = self.dequeue_at(timestamp).unwrap();
             #[cfg(test)]
             tracing::trace!(
                 after_queue_len = self.queue.len(),
@@ -108,7 +109,7 @@ where
         }
     }
 
-    fn dequeue(&mut self, _timestamp: Option<Instant>) -> Option<P> {
+    fn dequeue_at(&mut self, _timestamp: Instant) -> Option<P> {
         match self.queue.pop_front() {
             Some(packet) => {
                 self.now_bytes -= packet.l3_length() + self.bw_type.extra_length();

--- a/rattan-core/src/cells/bandwidth/queue/droptail.rs
+++ b/rattan-core/src/cells/bandwidth/queue/droptail.rs
@@ -1,4 +1,5 @@
 use std::collections::VecDeque;
+use tokio::time::Instant;
 
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
@@ -109,7 +110,7 @@ where
         }
     }
 
-    fn dequeue(&mut self) -> Option<P> {
+    fn dequeue(&mut self, _timestamp: Option<Instant>) -> Option<P> {
         match self.queue.pop_front() {
             Some(packet) => {
                 self.now_bytes -= packet.l3_length() + self.bw_type.extra_length();

--- a/rattan-core/src/cells/bandwidth/queue/droptail.rs
+++ b/rattan-core/src/cells/bandwidth/queue/droptail.rs
@@ -110,7 +110,7 @@ where
         }
     }
 
-    fn dequeue(&mut self, _timestamp: Option<Instant>) -> Option<P> {
+    fn dequeue_at(&mut self, _timestamp: Instant) -> Option<P> {
         match self.queue.pop_front() {
             Some(packet) => {
                 self.now_bytes -= packet.l3_length() + self.bw_type.extra_length();

--- a/rattan-core/src/cells/bandwidth/queue/infinite.rs
+++ b/rattan-core/src/cells/bandwidth/queue/infinite.rs
@@ -1,4 +1,5 @@
 use std::collections::VecDeque;
+use tokio::time::Instant;
 
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
@@ -55,7 +56,7 @@ where
         self.queue.push_back(packet);
     }
 
-    fn dequeue(&mut self) -> Option<P> {
+    fn dequeue(&mut self, _timestamp: Option<Instant>) -> Option<P> {
         self.queue.pop_front()
     }
 

--- a/rattan-core/src/cells/bandwidth/queue/infinite.rs
+++ b/rattan-core/src/cells/bandwidth/queue/infinite.rs
@@ -56,7 +56,7 @@ where
         self.queue.push_back(packet);
     }
 
-    fn dequeue(&mut self, _timestamp: Option<Instant>) -> Option<P> {
+    fn dequeue_at(&mut self, _timestamp: Instant) -> Option<P> {
         self.queue.pop_front()
     }
 

--- a/rattan-core/src/cells/bandwidth/queue/mod.rs
+++ b/rattan-core/src/cells/bandwidth/queue/mod.rs
@@ -106,7 +106,7 @@ where
                 break;
             }
         }
-        self.queue.dequeue(Some(timestamp))
+        self.queue.dequeue_at(timestamp)
     }
 
     pub fn next_call_time(&self) -> Instant {
@@ -131,8 +131,7 @@ where
     fn enqueue(&mut self, packet: P);
 
     /// If the queue is empty, return `None`
-    /// If the queue does not require a timestamp for dequeueing, pass None.
-    fn dequeue(&mut self, timestamp: Option<Instant>) -> Option<P>;
+    fn dequeue_at(&mut self, timestamp: Instant) -> Option<P>;
 
     fn is_empty(&self) -> bool;
 

--- a/rattan-core/src/cells/bandwidth/queue/mod.rs
+++ b/rattan-core/src/cells/bandwidth/queue/mod.rs
@@ -106,7 +106,7 @@ where
                 break;
             }
         }
-        self.queue.dequeue()
+        self.queue.dequeue(Some(timestamp))
     }
 
     pub fn next_call_time(&self) -> Instant {
@@ -131,7 +131,8 @@ where
     fn enqueue(&mut self, packet: P);
 
     /// If the queue is empty, return `None`
-    fn dequeue(&mut self) -> Option<P>;
+    /// If the queue does not require a timestamp for dequeueing, pass None.
+    fn dequeue(&mut self, timestamp: Option<Instant>) -> Option<P>;
 
     fn is_empty(&self) -> bool;
 

--- a/rattan-core/src/cells/token_bucket/mod.rs
+++ b/rattan-core/src/cells/token_bucket/mod.rs
@@ -215,7 +215,7 @@ where
                 }
             }
             // Send this packet!
-            let mut current_packet = if let Some(head_packet) = self.packet_queue.dequeue() {
+            let mut current_packet = if let Some(head_packet) = self.packet_queue.dequeue(None) {
                 if let Some(new_packet) = new_packet {
                     self.packet_queue.enqueue(new_packet);
                 }

--- a/rattan-core/src/cells/token_bucket/mod.rs
+++ b/rattan-core/src/cells/token_bucket/mod.rs
@@ -215,16 +215,17 @@ where
                 }
             }
             // Send this packet!
-            let mut current_packet = if let Some(head_packet) = self.packet_queue.dequeue(None) {
-                if let Some(new_packet) = new_packet {
-                    self.packet_queue.enqueue(new_packet);
+            let mut current_packet =
+                if let Some(head_packet) = self.packet_queue.dequeue_at(self.logical_clock) {
+                    if let Some(new_packet) = new_packet {
+                        self.packet_queue.enqueue(new_packet);
+                    }
+                    head_packet.into()
+                } else {
+                    // Send directly without enqueue
+                    new_packet
                 }
-                head_packet.into()
-            } else {
-                // Send directly without enqueue
-                new_packet
-            }
-            .expect("There should be a packet here");
+                .expect("There should be a packet here");
 
             debug!(
                 "Send packet, timestamp {:?} -> {:?}",


### PR DESCRIPTION
### Summary

Add an `Option<Instant>` timestamp parameter to `PacketQueue::dequeue()` to support time-aware queue operations. The `CoDel` queue uses this parameter to avoid `Instant::now()` calls, while simple queue implementations (DropHead, DropTail,
Infinite) ignore it with `None`.

### Usage

This change lays the groundwork for PR #197 (redpie branch) by providing the necessary timestamp plumbing in the `PacketQueue` trait. The subsequent PR will make use of this parameter to implement its feature.