### PR TITLE
refactor(queue): remove retain from PacketQueue trait

### DIFF
--- a/rattan-core/src/cells/bandwidth/queue/codel.rs
+++ b/rattan-core/src/cells/bandwidth/queue/codel.rs
@@ -299,11 +299,4 @@ where
     fn length(&self) -> usize {
         self.queue.len()
     }
-
-    fn retain<F>(&mut self, mut f: F)
-    where
-        F: FnMut(&P) -> bool,
-    {
-        self.queue.retain(|packet| f(packet));
-    }
 }

--- a/rattan-core/src/cells/bandwidth/queue/drophead.rs
+++ b/rattan-core/src/cells/bandwidth/queue/drophead.rs
@@ -137,11 +137,4 @@ where
     fn length(&self) -> usize {
         self.queue.len()
     }
-
-    fn retain<F>(&mut self, mut f: F)
-    where
-        F: FnMut(&P) -> bool,
-    {
-        self.queue.retain(|packet| f(packet));
-    }
 }

--- a/rattan-core/src/cells/bandwidth/queue/droptail.rs
+++ b/rattan-core/src/cells/bandwidth/queue/droptail.rs
@@ -138,11 +138,30 @@ where
     fn length(&self) -> usize {
         self.queue.len()
     }
+}
 
-    fn retain<F>(&mut self, mut f: F)
+impl<P> DropTailQueue<P>
+where
+    P: Packet,
+{
+    /// Retain only the packets for which `f` returns `true`, dropping the rest
+    /// while keeping `now_bytes` consistent with the remaining packets.
+    ///
+    /// Used by the token bucket cell to drop packets that exceed the queue's
+    /// `max_size` when it is shrunk (see `TokenBucketCellEgress::set_config`).
+    pub fn retain<F>(&mut self, mut f: F)
     where
         F: FnMut(&P) -> bool,
     {
-        self.queue.retain(|packet| f(packet));
+        let extra_length = self.bw_type.extra_length();
+        let now_bytes = &mut self.now_bytes;
+        self.queue.retain(|packet| {
+            if f(packet) {
+                true
+            } else {
+                *now_bytes -= packet.l3_length() + extra_length;
+                false
+            }
+        });
     }
 }

--- a/rattan-core/src/cells/bandwidth/queue/infinite.rs
+++ b/rattan-core/src/cells/bandwidth/queue/infinite.rs
@@ -78,11 +78,4 @@ where
     fn length(&self) -> usize {
         self.queue.len()
     }
-
-    fn retain<F>(&mut self, mut f: F)
-    where
-        F: FnMut(&P) -> bool,
-    {
-        self.queue.retain(|packet| f(packet));
-    }
 }

--- a/rattan-core/src/cells/bandwidth/queue/mod.rs
+++ b/rattan-core/src/cells/bandwidth/queue/mod.rs
@@ -157,10 +157,4 @@ where
     fn get_front_size(&self) -> Option<usize>;
 
     fn length(&self) -> usize;
-
-    fn retain<F>(&mut self, _f: F)
-    where
-        F: FnMut(&P) -> bool,
-    {
-    }
 }


### PR DESCRIPTION
The trait-level `retain` was buggy in every impl (never updated `now_bytes` after dropping packets) and is only used by TBF's DropTail queue, so maintaining it on the trait isn't worth it. Remove it from the trait and reimplement it as an inherent method on `DropTailQueue<P>` that correctly maintains `now_bytes`.