### PR TITLE
ci: reduce self-hosted runner disk I/O

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name != github.repository
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: recursive
       - uses: dtolnay/rust-toolchain@stable
@@ -39,7 +39,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name != github.repository
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: recursive
       - uses: dtolnay/rust-toolchain@stable
@@ -58,7 +58,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name != github.repository
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: recursive
       - uses: dtolnay/rust-toolchain@stable
@@ -71,7 +71,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name != github.repository
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: recursive
       - uses: actions-rust-lang/audit@v1

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -15,7 +15,7 @@ jobs:
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup mdBook
         uses: peaceiris/actions-mdbook@v2

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -20,7 +20,7 @@ jobs:
       cancel-in-progress: false
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
           token: ${{ secrets.RELEASE_PLZ_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,7 +56,7 @@ jobs:
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           persist-credentials: false
           submodules: recursive
@@ -116,7 +116,7 @@ jobs:
       - name: enable windows longpaths
         run: |
           git config --global core.longpaths true
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           persist-credentials: false
           submodules: recursive
@@ -175,7 +175,7 @@ jobs:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       BUILD_MANIFEST_NAME: target/distrib/global-dist-manifest.json
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           persist-credentials: false
           submodules: recursive
@@ -225,7 +225,7 @@ jobs:
     outputs:
       val: ${{ steps.host.outputs.manifest }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           persist-credentials: false
           submodules: recursive
@@ -290,7 +290,7 @@ jobs:
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           persist-credentials: false
           submodules: recursive

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,6 @@ jobs:
   test-all-features:
     name: cargo test with all features
     strategy:
-      max-parallel: 1
       fail-fast: false
       matrix:
         include:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,25 +39,17 @@ jobs:
       # Overrides the `debug = true` (for cargo flamegraph) in the root Cargo.toml
       # to cut release build artifact size and disk writes.
       CARGO_PROFILE_RELEASE_DEBUG: "line-tables-only"
+      # LLVM is preinstalled on the runners (apt: clang-N llvm-N libclang-N-dev).
+      # Point bindgen (via libbpf-sys) at the matching preinstalled libclang.
+      LIBCLANG_PATH: /usr/lib/llvm-${{ matrix.llvm }}/lib
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
       - uses: dtolnay/rust-toolchain@stable
       - run: sudo apt update && sudo apt install ethtool iputils-ping iproute2 iperf3 pkg-config m4 libelf-dev libpcap-dev gcc-multilib libnftnl-dev libmnl-dev autoconf automake autopoint flex bison gawk libtool -y
-      - name: Cache LLVM and Clang
-        id: cache-llvm
-        uses: maxnowack/local-cache@v2
-        with:
-          path: |
-            C:/Program Files/LLVM
-            ./llvm
-          key: llvm-${{ matrix.llvm }}
-      - name: Install LLVM and Clang
-        uses: KyleMayes/install-llvm-action@v2
-        with:
-          version: ${{ matrix.llvm }}
-          cached: ${{ steps.cache-llvm.outputs.cache-hit }}
+      - name: Use preinstalled LLVM ${{ matrix.llvm }}
+        run: echo "/usr/lib/llvm-${{ matrix.llvm }}/bin" >> "$GITHUB_PATH"
       - name: Install nextest
         uses: taiki-e/install-action@nextest
       - run: cargo nextest run --profile ci -F http,xdp --release --workspace

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,6 +35,11 @@ jobs:
             llvm: "17"
     runs-on: ${{ matrix.kernel }}
     if: github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name != github.repository
+    env:
+      # CI only needs line numbers for panic backtraces, not full DWARF.
+      # Overrides the `debug = true` (for cargo flamegraph) in the root Cargo.toml
+      # to cut release build artifact size and disk writes.
+      CARGO_PROFILE_RELEASE_DEBUG: "line-tables-only"
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,7 +43,7 @@ jobs:
       # Point bindgen (via libbpf-sys) at the matching preinstalled libclang.
       LIBCLANG_PATH: /usr/lib/llvm-${{ matrix.llvm }}/lib
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: recursive
       - uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -36,7 +36,7 @@ jobs:
       # Point bindgen (via libbpf-sys) at the matching preinstalled libclang.
       LIBCLANG_PATH: /usr/lib/llvm-${{ matrix.llvm }}/lib
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: recursive
       - uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -32,25 +32,17 @@ jobs:
       # Overrides the `debug = true` (for cargo flamegraph) in the root Cargo.toml
       # to cut release build artifact size and disk writes.
       CARGO_PROFILE_RELEASE_DEBUG: "line-tables-only"
+      # LLVM is preinstalled on the runners (apt: clang-N llvm-N libclang-N-dev).
+      # Point bindgen (via libbpf-sys) at the matching preinstalled libclang.
+      LIBCLANG_PATH: /usr/lib/llvm-${{ matrix.llvm }}/lib
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
       - uses: dtolnay/rust-toolchain@stable
       - run: sudo apt update && sudo apt install ethtool iputils-ping iproute2 iperf3 datamash bc pkg-config m4 libelf-dev libpcap-dev gcc-multilib libnftnl-dev libmnl-dev autoconf automake autopoint flex bison gawk libtool -y
-      - name: Cache LLVM and Clang
-        id: cache-llvm
-        uses: maxnowack/local-cache@v2
-        with:
-          path: |
-            C:/Program Files/LLVM
-            ./llvm
-          key: llvm-${{ matrix.llvm }}
-      - name: Install LLVM and Clang
-        uses: KyleMayes/install-llvm-action@v2
-        with:
-          version: ${{ matrix.llvm }}
-          cached: ${{ steps.cache-llvm.outputs.cache-hit }}
+      - name: Use preinstalled LLVM ${{ matrix.llvm }}
+        run: echo "/usr/lib/llvm-${{ matrix.llvm }}/bin" >> "$GITHUB_PATH"
       - run: sudo ./scripts/clean_stdenv.sh -a
       - name: Performance verification
         run: |

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -27,6 +27,11 @@ jobs:
           - kernel: "6.12"
             llvm: "17"
     runs-on: ${{ matrix.kernel }}
+    env:
+      # CI only needs line numbers for panic backtraces, not full DWARF.
+      # Overrides the `debug = true` (for cargo flamegraph) in the root Cargo.toml
+      # to cut release build artifact size and disk writes.
+      CARGO_PROFILE_RELEASE_DEBUG: "line-tables-only"
     steps:
       - uses: actions/checkout@v4
         with:

--- a/ci/images/ansible/Dockerfile.runner
+++ b/ci/images/ansible/Dockerfile.runner
@@ -1,0 +1,27 @@
+# Extends the upstream github-runner image with a preinstalled LLVM/Clang
+# toolchain, so CI jobs (bindgen via libbpf-sys, BPF compilation) don't fetch
+# LLVM on every run. Everything lands under /usr/lib/llvm-${LLVM_VERSION},
+# matching the PATH / LIBCLANG_PATH that the test and verify workflows expect.
+ARG BASE_TAG=ubuntu-noble
+FROM myoung34/github-runner:${BASE_TAG}
+
+# 14 for focal (kernel 5.4), 17 for jammy/noble. Overridden per image by ansible.
+ARG LLVM_VERSION=17
+
+# Prefer distro packages (present on noble for 17); fall back to apt.llvm.org
+# for versions the distro repos lack (14 on focal, 17 on jammy).
+RUN set -eux; \
+    export DEBIAN_FRONTEND=noninteractive; \
+    apt-get update; \
+    if ! apt-get install -y --no-install-recommends \
+            "clang-${LLVM_VERSION}" "llvm-${LLVM_VERSION}" "libclang-${LLVM_VERSION}-dev"; then \
+        apt-get install -y --no-install-recommends \
+            wget gnupg lsb-release ca-certificates software-properties-common; \
+        wget -qO /tmp/llvm.sh https://apt.llvm.org/llvm.sh; \
+        chmod +x /tmp/llvm.sh; \
+        /tmp/llvm.sh "${LLVM_VERSION}"; \
+        apt-get install -y --no-install-recommends "libclang-${LLVM_VERSION}-dev"; \
+    fi; \
+    test -x "/usr/lib/llvm-${LLVM_VERSION}/bin/clang"; \
+    test -e "/usr/lib/llvm-${LLVM_VERSION}/lib/libclang.so"; \
+    rm -rf /var/lib/apt/lists/* /tmp/llvm.sh

--- a/ci/images/ansible/docker-compose.yml.j2
+++ b/ci/images/ansible/docker-compose.yml.j2
@@ -1,6 +1,6 @@
 services:
   worker:
-    image: myoung34/github-runner:{{ tag }}
+    image: rattan/github-runner:{{ tag }}
     container_name: github-runner
     restart: always
     privileged: true

--- a/ci/images/ansible/github-runner.yml
+++ b/ci/images/ansible/github-runner.yml
@@ -4,6 +4,12 @@
     path: /etc/runner
     state: directory
 
+- name: derive LLVM version from kernel
+  ansible.builtin.set_fact:
+    # 5.4 (focal) pins LLVM 14; newer kernels use 17. Matches the test/verify
+    # workflow matrix and the LIBCLANG_PATH / PATH they set.
+    llvm_version: "{{ '14' if kernel_version == '5.4' else '17' }}"
+
 - name: write docker client proxy config for job-spawned containers
   become: true
   ansible.builtin.copy:
@@ -19,20 +25,44 @@
         }
       }
 
+- name: copy github-runner Dockerfile
+  become: true
+  ansible.builtin.copy:
+    src: Dockerfile.runner
+    dest: /etc/runner/Dockerfile.runner
+    mode: "0644"
+
 - name: copy github-runner docker-compose file
   become: true
   ansible.builtin.template:
     src: docker-compose.yml.j2
     dest: /etc/runner/docker-compose.yml
 
-- name: poll a image
+- name: build github-runner image with preinstalled LLVM
   become: true
   community.docker.docker_image:
-    name: "docker.io/myoung34/github-runner:{{ tag }}"
-    source: pull
+    name: rattan/github-runner
+    tag: "{{ tag }}"
+    source: build
+    force_source: true
+    build:
+      path: /etc/runner
+      dockerfile: Dockerfile.runner
+      # Pull a fresh upstream base each build.
+      pull: true
+      args:
+        BASE_TAG: "{{ tag }}"
+        LLVM_VERSION: "{{ llvm_version }}"
+        http_proxy: "{{ http_proxy | default('') }}"
+        https_proxy: "{{ http_proxy | default('') }}"
+        HTTP_PROXY: "{{ http_proxy | default('') }}"
+        HTTPS_PROXY: "{{ http_proxy | default('') }}"
+        no_proxy: "localhost,127.0.0.1,::1"
 
 - name: start the github-runner container
   become: true
   community.docker.docker_compose_v2:
     project_src: /etc/runner
     state: present
+    # Image is built locally above; never try to pull it from a registry.
+    pull: never


### PR DESCRIPTION
Lower disk I/O on the slow self-hosted runners (test + verify):

- **Preinstall LLVM in the runner image** (ansible-built `github-runner`), dropping the per-run `Cache`/`Install LLVM` steps — a ~1 GB local copy, ~8 min on these disks. Jobs use `/usr/lib/llvm-<N>` via `PATH`/`LIBCLANG_PATH` (5.4->14, else->17).
- **`CARGO_PROFILE_RELEASE_DEBUG=line-tables-only`** — release test binaries were ~92% DWARF; cuts write volume, keeps panic line numbers.
- **Drop `max-parallel: 1`** in the test workflow.
